### PR TITLE
fixed #25: Correção do navbar na versão responsiva

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -367,6 +367,7 @@ header {
 			display: none;
 			width: 100%;
 			border-top: 2px solid vars.$blue-dark;
+			background-color: white;
 		}
 
 		.brand {
@@ -379,7 +380,7 @@ header {
 
 		.menu {
 			display: block;
-			width: 700px;
+			//width: 700px;
 			clear: both;
 
 			.dropdown-menu {


### PR DESCRIPTION
Na versão para mobile existia um erro quando abria o navbar, como pode ser visto abaixo:

![image](https://user-images.githubusercontent.com/28739009/230930555-398304cd-68e3-441d-b8e2-3f2969af5c0a.png)

- O erro se tratava do tamanho fixo do navbar. Foi preciso apagar essa linha no css.
- Também foi inserido um fundo branco para o navbar para facilitar na leitura do mesmo.